### PR TITLE
deps: bump imgproxy to v4.0.7 + fix varnish dev tmpfs perms

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
     volumes:
       - "./varnish.vcl:/etc/varnish/default.vcl"
     tmpfs:
-      - /var/lib/varnish:exec
+      - /var/lib/varnish:exec,mode=1777
     environment:
       - VARNISH_SIZE=20G
     command: "-p default_ttl=86400"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
 #      - "traefik.http.routers.traefik.service=api@internal"
 
   imgproxy:
-    image: ghcr.io/imgproxy/imgproxy:v3.31.3
+    image: ghcr.io/imgproxy/imgproxy:v4.0.7
     restart: unless-stopped
     networks:
       - trouvaille

--- a/trouvaille-back/docker-compose.yml
+++ b/trouvaille-back/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   imgproxy:
-    image: ghcr.io/imgproxy/imgproxy:v3.31.3
+    image: ghcr.io/imgproxy/imgproxy:v4.0.7
     restart: unless-stopped
     networks:
       - trouvaille-back

--- a/trouvaille-back/docker-compose.yml
+++ b/trouvaille-back/docker-compose.yml
@@ -22,7 +22,7 @@ services:
     volumes:
       - "../varnish.vcl:/etc/varnish/default.vcl"
     tmpfs:
-      - /var/lib/varnish:exec
+      - /var/lib/varnish:exec,mode=1777
     environment:
       - VARNISH_SIZE=20G
     command: "-p default_ttl=86400"


### PR DESCRIPTION
## imgproxy bump
Bumps imgproxy from `v3.31.3` to `v4.0.7` (latest) in both `docker-compose.yml` and `trouvaille-back/docker-compose.yml`.

[v4.0.0](https://github.com/imgproxy/imgproxy/releases/tag/v4.0.0) removed some deprecated configs and changed a few defaults (etag generation, `USE_ETAG`/`USE_LAST_MODIFIED` default-on, GCS no longer auto-enabled, SVG DPI 72→96). **None affect this setup** — it only uses `AUTO_WEBP/AVIF/JXL`, `QUALITY`, `MAX_SRC_RESOLUTION`, `LOCAL_FILESYSTEM_ROOT` and `local://` source URLs.

Supersedes #248 and #252, which targeted v4.0.5.

## varnish tmpfs fix (found while verifying locally)
Starting the stack revealed a **pre-existing** crash-loop in the `varnish` service:
```
Error: Cannot create working directory '/var/lib/varnish/varnishd': Permission denied
```
`varnish:9.0.3` runs as uid 1000, but the tmpfs at `/var/lib/varnish` mounts root-owned mode `0755`, so varnishd can't create its working dir. Added `mode=1777` to the tmpfs mount.

## Verification
Ran the upgraded imgproxy through varnish on `:38080` (the dev backend path), using the exact request shape the backend issues (`/insecure/rs:fit:W:H/plain/local:///<path>`):

| Accept | Result |
|---|---|
| `image/webp` | 200, `image/webp`, valid, 1200×800→300×200 ✓ |
| `image/avif` | 200, `image/avif`, valid ✓ |
| `image/jxl`  | 200, `image/jxl` ✓ |
| `image/*`    | 200, `image/jpeg`, valid ✓ |

Varnish stays Up (no restart loop) and cache HITs confirmed via `X-Varnish` headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)